### PR TITLE
fix: add platform architecture detection for spectral download

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -53,7 +53,7 @@ download_release() {
     ;;
   esac
 
-  if [[ $(semVer $version) -gt $(semVer "6.6.0") ]]; then platform+="-x64"; fi
+  if [[ $(semVer $version) -gt $(semVer "6.6.0") ]]; then platform+="-$(uname -m)"; fi
 
   url="$GH_REPO/releases/download/v${version}/spectral-$platform"
 


### PR DESCRIPTION
Replace hard-coded `x64` with `$(uname -m)` architecture.